### PR TITLE
Update S2InitTwitter.groovy

### DIFF
--- a/scripts/S2InitTwitter.groovy
+++ b/scripts/S2InitTwitter.groovy
@@ -114,9 +114,9 @@ private void configure() {
 private void copyData() {
 	copyFile "$templateDir/spring-security-twitter.messages.properties.template",
 		"$appDir/i18n/spring-security-twitter.messages.properties"
-    copyFile "$resourceDir/sign-in-with-twitter-d.png",
+    copyFile "$springSecurityTwitterPluginDir/web-app/images/sign-in-with-twitter-d.png",
         "$webDir/images/sign-in-with-twitter-d.png"
-    copyFile "$resourceDir/twitter-auth.css",
+    copyFile "$springSecurityTwitterPluginDir/web-app/css/twitter-auth.css",
         "$webDir/css/twitter-auth.css"
 
 	generateFile "$templateDir/TwitterUser.groovy.connected.template",


### PR DESCRIPTION
copyFile source dir not correct. it causes s2-init-twitter command Error(Could not find file). checked on windows8.
