### PR TITLE
Use Authenticate URL instead of Authorize URL and Update to Spring Security Core 2.0

### DIFF
--- a/SpringSecurityTwitterGrailsPlugin.groovy
+++ b/SpringSecurityTwitterGrailsPlugin.groovy
@@ -1,8 +1,8 @@
 import com.the6hours.grails.springsecurity.twitter.DefaultTwitterAuthDao
 import com.the6hours.grails.springsecurity.twitter.TwitterAuthProvider
 import com.the6hours.grails.springsecurity.twitter.TwitterAuthFilter
-import org.codehaus.groovy.grails.plugins.springsecurity.SecurityFilterPosition
-import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.SecurityFilterPosition
+import grails.plugin.springsecurity.SpringSecurityUtils
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
 
 /* Copyright 2006-2010 the original author or authors.
@@ -26,7 +26,7 @@ class SpringSecurityTwitterGrailsPlugin {
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.0.0 > *"
 
-    Map dependsOn = ['springSecurityCore': '1.2.7.2 > *']
+    Map dependsOn = ['springSecurityCore': '2.0-RC2 > *']
     def license = 'APACHE'
 
     // resources that are excluded from plugin packaging

--- a/grails-app/controllers/com/the6hours/grails/springsecurity/twitter/TwitterAuthController.groovy
+++ b/grails-app/controllers/com/the6hours/grails/springsecurity/twitter/TwitterAuthController.groovy
@@ -1,6 +1,6 @@
 package com.the6hours.grails.springsecurity.twitter
 
-import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.SpringSecurityUtils
 
 class TwitterAuthController {
 

--- a/grails-app/taglib/com/the6hours/grails/springsecurity/twitter/TwitterAuthTagLib.groovy
+++ b/grails-app/taglib/com/the6hours/grails/springsecurity/twitter/TwitterAuthTagLib.groovy
@@ -1,6 +1,6 @@
 package com.the6hours.grails.springsecurity.twitter
 
-import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.SpringSecurityUtils
 
 /**
  * Twitter Auth tags

--- a/scripts/S2InitTwitter.groovy
+++ b/scripts/S2InitTwitter.groovy
@@ -74,7 +74,7 @@ private void fillConfig() {
         configFile.withWriterAppend {
             it.writeLine "\n"
             config.entrySet().each { Map.Entry conf ->
-                it.writeLine "grails.plugins.springsecurity.twitter.$conf.key='$conf.value'"
+                it.writeLine "grails.plugin.springsecurity.twitter.$conf.key='$conf.value'"
             }
         }
     }

--- a/src/groovy/com/the6hours/grails/springsecurity/twitter/DefaultTwitterAuthDao.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/twitter/DefaultTwitterAuthDao.groovy
@@ -2,8 +2,7 @@ package com.the6hours.grails.springsecurity.twitter
 
 import org.apache.log4j.Logger
 import org.codehaus.groovy.grails.commons.GrailsApplication
-import org.codehaus.groovy.grails.plugins.springsecurity.GormUserDetailsService
-import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.SpringSecurityUtils
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.context.ApplicationContext

--- a/src/groovy/com/the6hours/grails/springsecurity/twitter/TwitterAuthFilter.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/twitter/TwitterAuthFilter.groovy
@@ -1,6 +1,6 @@
 package com.the6hours.grails.springsecurity.twitter
 
-import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.SpringSecurityUtils
 import org.codehaus.groovy.grails.web.mapping.LinkGenerator
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter
 import org.springframework.security.core.Authentication

--- a/src/groovy/com/the6hours/grails/springsecurity/twitter/TwitterAuthFilter.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/twitter/TwitterAuthFilter.groovy
@@ -100,7 +100,7 @@ class TwitterAuthFilter extends AbstractAuthenticationProcessingFilter {
 
         OAuthToken requestToken = oauth.fetchRequestToken(url, null)
         request.session.setAttribute(REQUEST_TOKEN, requestToken)
-        String authorizeUrl = oauth.buildAuthorizeUrl(requestToken.value, (OAuth1Parameters) OAuth1Parameters.NONE)
+        String authorizeUrl = oauth.buildAuthenticateUrl(requestToken.value, (OAuth1Parameters) OAuth1Parameters.NONE)
         response.sendRedirect(authorizeUrl)
     }
 


### PR DESCRIPTION
I think it would be better if Twitter AuthenticateURL is used instead of Authorize URL to allow skipping the application approval page if you've already approved it before.
Also I've uploaded an update to Spring Security Core 2.0
