### PR TITLE
Updates Spring Social Twitter dependency

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -46,7 +46,7 @@ grails.project.dependency.resolution = {
                      'org.springframework.core',
                      'org.springframework.web'
         }
-        compile 'org.springframework.social:spring-social-twitter:1.0.3.RELEASE'
+        compile 'org.springframework.social:spring-social-twitter:1.1.0.RELEASE'
     }
 
     plugins {


### PR DESCRIPTION
I was trying to use this plugin with Grails 2.5.5 but I was getting this error:

```
| Error 2016-09-29 05:25:03,460 [http-bio-8080-exec-6] ERROR [/betting-pool].[default]  - Servlet.service() for servlet [default] in context with path [/betting-pool] threw exception [Filter execution threw an exception] with root cause
Message: org.springframework.http.converter.json.MappingJacksonHttpMessageConverter
    Line | Method
->>  366 | run                   in java.net.URLClassLoader$1
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
|    355 | run                   in     ''
|    354 | findClass . . . . . . in java.net.URLClassLoader
|    425 | loadClass             in java.lang.ClassLoader
|     56 | attemptAuthentication in com.the6hours.grails.springsecurity.twitter.TwitterAuthFilter
|     46 | doFilter              in com.the6hours.grails.springsecurity.facebook.FacebookAuthRedirectFilter
|     62 | doFilter . . . . . .  in grails.plugin.springsecurity.web.authentication.logout.MutableLogoutFilter
|     59 | doFilter              in grails.plugin.springsecurity.web.SecurityRequestHolderFilter
|   1145 | runWorker . . . . . . in java.util.concurrent.ThreadPoolExecutor
|    615 | run                   in java.util.concurrent.ThreadPoolExecutor$Worker
^    745 | run . . . . . . . . . in java.lang.Thread
```

This happens because `MappingJacksonHttpMessageConverter` was changed in Spring 4.1.X to `MappingJackson2HttpMessageConverter` so is necesary to update Spring Social Twitter.
